### PR TITLE
npm version handle same version during build action

### DIFF
--- a/npm-build/action.yml
+++ b/npm-build/action.yml
@@ -137,7 +137,7 @@ runs:
     - shell: bash
       name: version package
       run: |
-        npm version ${{ steps.semver.outputs.new_tag || steps.custom.outputs.new_tag }} --no-git-tag-version --ignore-scripts
+        npm version ${{ steps.semver.outputs.new_tag || steps.custom.outputs.new_tag }} --no-git-tag-version --allow-same-version --ignore-scripts
     
     - shell: bash
       name: install


### PR DESCRIPTION
ignoring same version (it might already have been set)

npm er mer kresen enn yarn ser det ut til. 
yarn har ikke den samme funksjonaliteten, antar den godtar det by default i motsetning til npm

* npm version

https://docs.npmjs.com/cli/v8/commands/npm-version


* yarn version
 
https://classic.yarnpkg.com/en/docs/cli/version


