### PR TITLE
chore/Version workspace packages

### DIFF
--- a/npm-build/action.yml
+++ b/npm-build/action.yml
@@ -141,6 +141,14 @@ runs:
         npm version ${{ steps.semver.outputs.new_tag || steps.custom.outputs.new_tag }} --no-git-tag-version --allow-same-version --ignore-scripts
     
     - shell: bash
+      name: version workspaces
+      run: |
+        workspaces=$(npm pkg get workspaces)
+        if [[ $workspaces != "{}" ]]; then
+          npm pkg set version=$(npm pkg get version) --workspaces --json        
+        fi
+
+    - shell: bash
       name: install
       run: |
         npm ci

--- a/yarn-build/action.yml
+++ b/yarn-build/action.yml
@@ -136,6 +136,14 @@ runs:
         yarn version --new-version ${{ steps.semver.outputs.new_tag || steps.custom.outputs.new_tag }} --no-git-tag-version --no-commit-hooks
 
     - shell: bash
+      name: version workspaces
+      run: |
+        workspaces=$(npm pkg get workspaces)
+        if [[ $workspaces != "{}" ]]; then
+          npm pkg set version=$(npm pkg get version) --workspaces --json        
+        fi
+
+    - shell: bash
       name: install
       run: |
         yarn install --frozen-lockfile


### PR DESCRIPTION
Packages should have correct version before build-step. Couldn't find the correct equivalent for yarn - but npm is bundled along with yarn so... 