### PR TITLE
feature/Run number for PR

### DIFF
--- a/get-version/action.yml
+++ b/get-version/action.yml
@@ -16,6 +16,9 @@ inputs:
     description: Initial version if there isn't any tags
     required: false
     default: 0.0.0
+  INITIAL_BUILDNUMBER:
+    description: If not defined, the first prerelease build-number will be set as workflow run number
+    required: false
   WITH_V:
     description: Tag version with v character.
     required: false
@@ -27,9 +30,7 @@ inputs:
   PRERELEASE_SUFFIX:
     description: Prerelease suffix for your versions, default to your branchname. Note this will only be used if a it's a prerelease
     required: false
-  PRERELEASE_USERUN:
-    required: false
-    default: 'false'
+  
   DEFAULT_BRANCH:
     description: Default main branch, other than this branch will be treated as a prerelease
     required: false
@@ -156,7 +157,7 @@ runs:
           if [[ "$pre_tag" == *"$new"* ]]; then
               new=$(semver -i prerelease $pre_tag --preid $prerelease); part="pre-$part"
           else
-              new="$new-$prerelease.$run_number"; part="pre-$part"
+              new="$new-$prerelease.$initial_build_number"; part="pre-$part"
           fi
         fi
 
@@ -175,7 +176,7 @@ runs:
         with_v: ${{ contains(inputs.WITH_V, 'true') && 'v' || '' }}
         is_pr: ${{ github.ref == format('refs/heads/{0}', inputs.DEFAULT_BRANCH) && '0' || '1' }}
         prerelease: ${{ steps.branch.outputs.prerelease }}
-        run_number: ${{ contains(inputs.PRERELEASE_USERUN, 'true') && github.run_number || '1' }}
+        initial_build_number: ${{ inputs.INITIAL_BUILDNUMBER || github.run_number || '1' }}
 
     - shell: bash
       name: output

--- a/get-version/action.yml
+++ b/get-version/action.yml
@@ -27,10 +27,14 @@ inputs:
   PRERELEASE_SUFFIX:
     description: Prerelease suffix for your versions, default to your branchname. Note this will only be used if a it's a prerelease
     required: false
+  PRERELEASE_USERUN:
+    required: false
+    default: 'false'
   DEFAULT_BRANCH:
     description: Default main branch, other than this branch will be treated as a prerelease
     required: false
     default: ${{ github.event.repository.default_branch }}
+  
 
 outputs:
   new_tag:
@@ -152,7 +156,7 @@ runs:
           if [[ "$pre_tag" == *"$new"* ]]; then
               new=$(semver -i prerelease $pre_tag --preid $prerelease); part="pre-$part"
           else
-              new="$new-$prerelease.1"; part="pre-$part"
+              new="$new-$prerelease.$run_number"; part="pre-$part"
           fi
         fi
 
@@ -171,6 +175,7 @@ runs:
         with_v: ${{ contains(inputs.WITH_V, 'true') && 'v' || '' }}
         is_pr: ${{ github.ref == format('refs/heads/{0}', inputs.DEFAULT_BRANCH) && '0' || '1' }}
         prerelease: ${{ steps.branch.outputs.prerelease }}
+        run_number: ${{ contains(inputs.PRERELEASE_USERUN, 'true') && github.run_number || '1' }}
 
     - shell: bash
       name: output


### PR DESCRIPTION
Versioning is using tags to decide next version. When prerelease isn't tagged it will always end up with run-number `.1` as postfix. This PR will solve that, by adding the `RUN_NUMBER` instead.